### PR TITLE
chown SSH config files in the /etc/cray/ims directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,6 +124,7 @@ function run_user_shell {
 
     # Start the SSH server daemon
     ssh-keygen -A
+    chown -R root:root /etc/cray/ims
     /usr/sbin/sshd $SSHD_OPTIONS
 
     # Perform any other bootstrapping tasks here or run a script


### PR DESCRIPTION
## Summary and Scope

When running a customize or create job, the ims sshd container is failing to authenticate users via passwordless ssh due to the `/etc/cray/ims/known_hosts` file being owned by the NOBODY user. This change causes the sshd container to chown the files under `/etc/cray/ims` such that the files are all owned by root. This is as a result of changes for non-root work.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7694](https://connect.us.cray.com/jira/browse/CASMCMS-7694)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? No -- no helm chart
- Was downgrade tested? If not, why? No -- no helm chart
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable