### PR TITLE
CASMCMS-7970 - update dev.cray.com server addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
+## [Unreleased]
+### Changed
+- CASMCMS-7970 - update dev.cray.com server addresses.
 
-[1.0.0] - (no date)
+## [1.0.0] - (no date)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Dockerfile for IMS sshd environment
-FROM arti.dev.cray.com/baseos-docker-master-local/opensuse-leap:15.2 as base
+FROM arti.hpc.amslabs.hpecorp.net/baseos-docker-master-local/opensuse-leap:15.2 as base
 RUN zypper install -y openssh
 
 # Apply security patches


### PR DESCRIPTION
## Summary and Scope

Update the artifactory server the base image is being pulled from.  The old address is being retired.

## Issues and Related PRs
* Resolves [CASMCMS-7970](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7970)

## Testing
### Tested on:
  * Build system

### Test description:

This will be tested in depth when integrated into the services that use it.

## Risks and Mitigations

Low risk - using the same image, just changing the name of the server it is getting it from.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

