### PR TITLE
CASMTRIAGE-3913 - fix image root ownership on jailed customize job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2022-08-12
+### Changed 
+- CASMTRIAGE-3913 - fix the directory permissions if the incomming image has incorrect ownership.
+
 ## [1.6.0] - 2022-08-01
 ### Changed
 - CASMCMS-7970 - update dev.cray.com server addresses.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -117,6 +117,8 @@ function run_user_shell {
     if [ "$SSH_JAIL" = "True" ]
     then
         chmod 755 "$IMAGE_ROOT_PARENT"
+        chown root:root "$IMAGE_ROOT_PARENT"
+        chown root:root "$IMAGE_ROOT_PARENT/image-root"
         echo "Match User root" >> "$SSHD_CONFIG_FILE"
         echo "ChrootDirectory $IMAGE_ROOT_PARENT/image-root" >> "$SSHD_CONFIG_FILE"
         SIGNAL_FILE_COMPLETE=$IMAGE_ROOT_PARENT/image-root/tmp/complete


### PR DESCRIPTION
## Summary and Scope

The incoming image to be customized had odd ownership and group permissions on the root directory.  This caused the chroot to fail on the ssh connection from cfs into the jailed environment, so cfs was not able to operate on the image.

This changes the file ownership and permissions on the image root when the jailed env is set up.  Now, no matter what the ownership of the squashfs image is, the base image root directory will be set to 'root:root' and the jailed ssh connection will succeed.

## Issues and Related PRs
* Resolves [CASMTRIAGE-3913](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3913)

## Testing
### Tested on:
  * `Tyr`

### Test description:

I uploaded the new ims-sshd image to tyr and modified the ims configmap to use this image on new job creation.  When a new job was created using this ims-sshd image, the file permissions were correctly modified and cfs was able to communicate with this pod.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? N - not a service
- Was downgrade tested? If not, why? N - not a service
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a pretty low risk change as usually the permissions in the image on the root directory should be 'root:root' to start with.  This just corrects the odd cases where it isn't.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

