### PR TITLE
CASMCMS-8183 - Update entrypoint to set up dkms mounts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Spelling corrections.
+- Added volume mounts when dkms is enabled.
 
 ## [1.6.1] - 2022-08-12
 ### Changed 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,6 +125,30 @@ function run_user_shell {
         SIGNAL_FILE_FAILED=$IMAGE_ROOT_PARENT/image-root/tmp/failed
     fi
 
+    # If setting up for dkms permissions, do that now
+    echo "JOB_ENABLE_DMKS: $JOB_ENABLE_DKMS"
+    local is_dkms=$(echo $JOB_ENABLE_DKMS | tr '[:upper:]' '[:lower:]')
+    echo "is_dkms=$is_dkms"
+    if [ "$is_dkms" = "true" ]; then
+        if mount -t sysfs /sysfs /mnt/image/image-root/sys; then
+            echo "Mounted /sys"
+        else
+            echo "Failed to mount /sys"
+        fi
+        if mount -t proc /proc /mnt/image/image-root/proc; then
+            echo "Mounted /proc"
+        else
+            echo "Failed to mount /proc"
+        fi
+        if mount -t devtmpfs /devtmpfs /mnt/image/image-root/dev; then
+            echo "Mounted /dev"
+        else
+            echo "Failed to mount /dev"
+        fi
+    else
+        echo "DKMS not enabled"
+    fi
+
     # Start the SSH server daemon
     ssh-keygen -A
     chown -R root:root /etc/cray/ims


### PR DESCRIPTION
## Summary and Scope
Use a variable to determine if mounts needed by dkms should be set up or not.

## Issues and Related PRs
* Resolves [CASMCMS-8183](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8183)

## Testing
### Tested on:
  * `Mug`

### Test description:

Tested that the mounts are correctly in place when dkms is enabled, and not mounted when it is disabled.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Moderate risk due to a larger feature being enabled.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

