### PR TITLE
CASM-2374 - support DKMS in image builds and customizations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Spelling corrections.
 
 ## [1.6.1] - 2022-08-12
 ### Changed 
-- CASMTRIAGE-3913 - fix the directory permissions if the incomming image has incorrect ownership.
+- CASMTRIAGE-3913 - fix the directory permissions if the incoming image has incorrect ownership.
 
 ## [1.6.0] - 2022-08-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Spelling corrections.
+- Added volume mounts when dkms is enabled.
 
 ## [1.6.1] - 2022-08-12
 ### Changed 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,6 +125,30 @@ function run_user_shell {
         SIGNAL_FILE_FAILED=$IMAGE_ROOT_PARENT/image-root/tmp/failed
     fi
 
+    # If setting up for dkms permissions, do that now
+    echo "JOB_ENABLE_DMKS: $JOB_ENABLE_DKMS"
+    local is_dkms=$(echo $JOB_ENABLE_DKMS | tr '[:upper:]' '[:lower:]')
+    echo "is_dkms=$is_dkms"
+    if [ "$is_dkms" = "true" ]; then
+        if mount -t sysfs /sysfs /mnt/image/image-root/sys; then
+            echo "Mounted /sys"
+        else
+            echo "Failed to mount /sys"
+        fi
+        if mount -t proc /proc /mnt/image/image-root/proc; then
+            echo "Mounted /proc"
+        else
+            echo "Failed to mount /proc"
+        fi
+        if mount -t devtmpfs /devtmpfs /mnt/image/image-root/dev; then
+            echo "Mounted /dev"
+        else
+            echo "Failed to mount /dev"
+        fi
+    else
+        echo "DKMS not enabled"
+    fi
+
     # Start the SSH server daemon
     ssh-keygen -A
     chown -R root:root /etc/cray/ims


### PR DESCRIPTION
## Summary and Scope

This mounts the special directories that dkms needs to work with if IMS is set to run under kata.

## Issues and Related PRs
* Resolves [CASM-2374](https://jira-pro.its.hpecorp.net:8443/browse/CASM-2374)
* Change will also be needed in `ims repo`

## Testing
### Tested on:
  * `Mug`

### Test description:

The new images and charts were deployed via helm upgrade and verified that when dkms is enabled, the kernel modules can be build and installed correctly. When the dkms feature is not enabled, the added security permissions required are NOT supplied and the system is secure.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a larger change with a moderate risk, but required for dkms usage.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

