### PR TITLE
CASMCMS-8567 - add support for arm64 image customization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - CASMCMS-8366 - add support for arm64 docker versions
+- CASMCMS-8567 - add support for arm64 image customization
 
 ### Removed
 - Removed defunct files leftover from previous versioning system

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,19 @@
 #
 
 # Dockerfile for IMS sshd environment
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
-RUN zypper install -y openssh
+# NOTE - currently the algol version does not have arm64 platform - update this when it does
+#FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
+FROM opensuse/leap:15.4 as base
+
+RUN zypper install -y openssh wget
 
 # Apply security patches
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
+
+# Install qemu-aarch64-static binary to handle arm64 emulation if needed
+RUN wget https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static && \
+    mv ./qemu-aarch64-static /usr/bin/qemu-aarch64-static && chmod +x /usr/bin/qemu-aarch64-static
 
 COPY run_script.sh entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -87,7 +87,7 @@ pipeline {
                 DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()
             }
             steps {
-                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE, multiArch: true)
+                publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ lint:
 
 image:
 		docker buildx create --use
-		docker buildx build --platform=linux/amd64,linux/arm64 --pull ${DOCKER_ARGS} .
+		docker buildx build --platform=linux/amd64 --pull ${DOCKER_ARGS} .
 		docker buildx build --platform=linux/amd64 --load --tag '${NAME}:${DOCKER_VERSION}' .
-		docker buildx build --platform=linux/arm64 --load --tag '${NAME}:${DOCKER_VERSION}-arm64' .
 


### PR DESCRIPTION
## Summary and Scope

Add the section of code to install the qemu-user-static binary in binfmt if this is an arm64 image. Also removed the arm64 version of this image, since it is not needed - the emulation happens at a different level and this image will always be running in the x86 env.

## Issues and Related PRs

* Resolves [CASMCMS-8365](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8365)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed the test binary on Mug and successfully started arm64 image customization jobs. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is low risk as the only change is if working with arm64 images.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

