### PR TITLE
CASMCMS-8658 - add env vars with IMS information to ssh env.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2023-06-22
+### Added
+- CASMCMS-8658 - add env vars with IMS job options to ssh env
+
 ## [1.8.0] - 2023-05-18
 ### Added
 - CASMCMS-8366 - add support for arm64 docker versions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -179,6 +179,16 @@ function run_user_shell {
             echo ":qemu-aarch64:M::\x7f\x45\x4c\x46\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:F" >> /proc/sys/fs/binfmt_misc/register
         fi
     fi
+
+    ## Set up the env vars we want to make available to users
+    # Add vars to a script file
+    echo "export IMS_JOB_ID=$IMS_JOB_ID" >> "$ENV_SCRIPT"
+    echo "export IMS_ARCH=$BUILD_ARCH" >> "$ENV_SCRIPT"
+    echo "export IMS_DKMS_ENABLED=$JOB_ENABLE_DKMS" >> "$ENV_SCRIPT"
+    echo "exec bash -il" >> "$ENV_SCRIPT" # gives user an executable shell to use
+
+    # Force that script to be run on login from ssh
+    echo "ForceCommand $ENV_SCRIPT" >> "$SSHD_CONFIG_FILE"
 
     # Start the SSH server daemon
     ssh-keygen -A

--- a/env_script.sh
+++ b/env_script.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
 #
 # MIT License
 #
-# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,25 +22,5 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
-# Dockerfile for IMS sshd environment
-# NOTE - currently the algol version does not have arm64 platform - update this when it does
-#FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4 as base
-FROM opensuse/leap:15.4 as base
-
-RUN zypper install -y openssh wget
-
-# Apply security patches
-COPY zypper-refresh-patch-clean.sh /
-RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
-
-# Install qemu-aarch64-static binary to handle arm64 emulation if needed
-RUN wget https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static && \
-    mv ./qemu-aarch64-static /usr/bin/qemu-aarch64-static && chmod +x /usr/bin/qemu-aarch64-static
-
-COPY run_script.sh env_script.sh entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
-ENV SSHD_OPTIONS ""
-ENV IMAGE_ROOT_PARENT /mnt/image
-ENV CUSTOMIZATION_SCRIPT /run_script.sh
-ENV ENV_SCRIPT /env_script.sh
+# The IMS job adds env var definitions here so they are available to the
+# users ssh'ing into the customize job.


### PR DESCRIPTION
## Summary and Scope

Set up env vars in the IMS sshd container so that when someone (or something like ansible) ssh'es into the container there is information available about the job and what is set up.

These env vars are only part of the ssh config, so they are not baked into the image itself and will not be present when the image is booted on real hardware.

## Issues and Related PRs
* Resolves [CASMCMS-8658](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8658)

## Testing
### Tested on:
  * `Mug`

### Test description:

I put the new ims-sshd image on Mug and changed the customize configmap so that when a new job was created it exercised the new code. All env vars were present as expected and had correct values.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is low risk - just creating new specific env vars for downstream users to use.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

