### PR TITLE
CASMCMS--8704 - fix env vars added to jailed env.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.2] - 2023-07-06
+### Changed
+- CASMCMS-8704 - fix env vars added to jailed env.
+
 ## [1.8.1] - 2023-06-22
 ### Added
 - CASMCMS-8658 - add env vars with IMS job options to ssh env


### PR DESCRIPTION
## Summary and Scope

The mechanism used for getting IMS env vars set in an IMS customize job wasn't working correctly for jailed jobs, and also wasn't working correctly for the way ansible used ssh to customize an image.

This copies the env vars script to a location the user logging into a jailed chroot setup can access it, as well as modifying the script itself so that using ssh to execute commands works correctly.

## Issues and Related PRs
* Resolves [CASMCMS-8704](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8704)

## Testing
### Tested on:

  * `Mug`

### Test description:

The image that contains this change was installed on Mug and tested against ansible jobs, direct ssh login, and ssh execution. It appears to work correctly in al usage cases that we can think of.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a small risk as all use cases we could think of have been tested.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
