### PR TITLE
CASMCMS-8821 - Remote customize job workflow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8821 - add support for remote customize jobs.
+
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 RUN wget https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static && \
     mv ./qemu-aarch64-static /usr/bin/qemu-aarch64-static && chmod +x /usr/bin/qemu-aarch64-static
 
-COPY run_script.sh entrypoint.sh /
+COPY run_script.sh force_cmd.sh entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 ENV SSHD_OPTIONS ""
 ENV IMAGE_ROOT_PARENT /mnt/image

--- a/force_cmd.sh
+++ b/force_cmd.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,13 +22,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
-# See if this removed the double echo...
-set -x
-
-# This script is used by the ssh_config when forwarding ssh calls to a remote
-# build node.
 if [[ -z "$SSH_ORIGINAL_COMMAND" ]]; then
-    ssh root@${REMOTE_BUILD_NODE} "podman exec -it ims-${IMS_JOB_ID} /bin/sh"
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE}
+# NOTE: this does not currently work for sftp - try somthing like below to make it work?
+#elif [[ "$SSH_ORIGINAL_COMMAND" == "internal-sftp" ]]; then
+#    sftp -P 2022 root@${REMOTE_BUILD_NODE}
 else
-    ssh root@${REMOTE_BUILD_NODE} "podman exec ims-${IMS_JOB_ID} /bin/sh -c '$SSH_ORIGINAL_COMMAND'"
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE} $SSH_ORIGINAL_COMMAND
+fi


### PR DESCRIPTION
## Summary and Scope

This adds support for remote customize IMS jobs. It works in conjunction with changes in ims and ims-utils to set up, use, and tear down a remote job.

## Issues and Related PRs

* Resolves [CASMCMS-8821](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8821)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed the new version of ims, ims-utils, and ims-sshd and ran remote and local jobs with and without ssh jails. All work as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Same risk as the rest of this project.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

