### PR TITLE
CASMCMS-8897 - build aarch64 version of image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CASMCMS-8821 - add support for remote customize jobs.
 - CASMCMS-8818 - add support for ssh key injection.
+- CASMCMS-8897 - changes for aarch64 remote build.
 
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,8 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 image:
-		# NOTE: add ',linux/arm64' to the platform arg to also build arm64 image
 		docker buildx create --use
-		docker buildx build --push --platform=linux/amd64 ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .
+		docker buildx build --push --platform=linux/amd64,linux/arm64 ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .
 
 image_local:
 		docker buildx create --use


### PR DESCRIPTION
## Summary and Scope

Create an aarch64 version of the image. This is used as a base image for the remote customize job image. It needs to have both x86 and aarch64 versions published for the aarch64 image build to work.

## Issues and Related PRs
* Resolves [CASMCMS-8897](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8897)

## Testing
### Tested on:
  * `Baldar`

### Test description:

Installed the new binary on the machine and set up a blanca peak node as the remote build node. This change was required to build the correct image to run on the remote build node.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Minor risk compared to the entire project.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

