### PR TITLE
CASMCMS-8895 - allow multiple concurrent remote customize jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8821 - add support for remote customize jobs.
 - CASMCMS-8818 - add support for ssh key injection.
 - CASMCMS-8897 - changes for aarch64 remote build.
+- CASMCMS-8895 - allow multiple concurrent remote customize jobs.
 
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/force_cmd.sh
+++ b/force_cmd.sh
@@ -22,11 +22,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# Set up the remote port varible
+IMAGE_ROOT_PARENT=${1:-/mnt/image}
+REMOTE_PORT_FILE=$IMAGE_ROOT_PARENT/remote_port
+REMOTE_PORT=$(cat ${REMOTE_PORT_FILE})
+
 if [[ -z "$SSH_ORIGINAL_COMMAND" ]]; then
-    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE}
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${REMOTE_PORT} root@${REMOTE_BUILD_NODE}
 # NOTE: this does not currently work for sftp - try somthing like below to make it work?
 #elif [[ "$SSH_ORIGINAL_COMMAND" == "internal-sftp" ]]; then
 #    sftp -P 2022 root@${REMOTE_BUILD_NODE}
 else
-    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE} $SSH_ORIGINAL_COMMAND
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${REMOTE_PORT} root@${REMOTE_BUILD_NODE} $SSH_ORIGINAL_COMMAND
 fi


### PR DESCRIPTION
## Summary and Scope

Change the scripts to look for an unused port on the remote build node and start / connect to the remote container using that available port. This allows multiple jobs to run instead of having a single hard-coded port that is used.

## Issues and Related PRs
* Resolves [CASMCMS-8895](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8895)

## Testing
### Tested on:
  * `Tyr`

### Test description:

I updated the version of the images being used to the test image and ran through multiple scenarios of kicking off many remote customize jobs in rapid succession. In the logs I verified it always correctly sorted out finding an available port with no unhandled collisions.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No riskier than anything else here...

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

