### PR TITLE
CASM-4349 - add remote build node capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CASMCMS-8821 - add support for remote customize jobs.
 - CASMCMS-8818 - add support for ssh key injection.
+- CASMCMS-8897 - changes for aarch64 remote build.
 
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8821 - add support for remote customize jobs.
+
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8821 - add support for remote customize jobs.
 - CASMCMS-8818 - add support for ssh key injection.
 - CASMCMS-8897 - changes for aarch64 remote build.
+- CASMCMS-8895 - allow multiple concurrent remote customize jobs.
 
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - CASMCMS-8821 - add support for remote customize jobs.
+- CASMCMS-8818 - add support for ssh key injection.
 
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2018-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2018-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@ RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 RUN wget https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-aarch64-static && \
     mv ./qemu-aarch64-static /usr/bin/qemu-aarch64-static && chmod +x /usr/bin/qemu-aarch64-static
 
-COPY run_script.sh entrypoint.sh /
+COPY run_script.sh force_cmd.sh entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 ENV SSHD_OPTIONS ""
 ENV IMAGE_ROOT_PARENT /mnt/image

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,8 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 image:
-		# NOTE: add ',linux/arm64' to the platform arg to also build arm64 image
 		docker buildx create --use
-		docker buildx build --push --platform=linux/amd64 ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .
+		docker buildx build --push --platform=linux/amd64,linux/arm64 ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${DOCKER_VERSION}' .
 
 image_local:
 		docker buildx create --use

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,7 +118,12 @@ function run_user_shell {
     # NOTE:
     #  - all env vars must be on one line
     #  - this must be before the 'Match' line in a jailed setup
-    echo "SetEnv IMS_JOB_ID=$IMS_JOB_ID IMS_ARCH=$BUILD_ARCH IMS_DKMS_ENABLED=$JOB_ENABLE_DKMS" >> "$SSHD_CONFIG_FILE"
+    echo "SetEnv IMS_JOB_ID=$IMS_JOB_ID IMS_ARCH=$BUILD_ARCH IMS_DKMS_ENABLED=$JOB_ENABLE_DKMS REMOTE_BUILD_NODE=$REMOTE_BUILD_NODE" >> "$SSHD_CONFIG_FILE"
+
+    # Set up forwarding to remote node if needed
+    if [[ -n "${REMOTE_BUILD_NODE}" ]]; then
+        echo "ForceCommand /force_script.sh" >> "$SSHD_CONFIG_FILE"
+    fi
 
     # Setup SSH jail
     if [ "$SSH_JAIL" = "True" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -310,11 +310,6 @@ function fetch_remote_artifacts {
         # copy image files from remote machine to job pod
         scp -o StrictHostKeyChecking=no root@${REMOTE_BUILD_NODE}:/tmp/ims_${IMS_JOB_ID}/* ${IMAGE_ROOT_PARENT}
 
-        # NOTE - need to look at prepare step to see where these came from:
-        #    /mnt/image/image-root/cray/*
-        #    /mnt/image/image-root/resolve.conf
-        # ??? - do they need to be added to the squashfs file? Added some other way?
-
         # unpack squashfs
         mkdir -p ${IMAGE_ROOT_PARENT}/
         unsquashfs -f -d ${IMAGE_ROOT_PARENT}/image-root ${IMAGE_ROOT_PARENT}/transfer.sqsh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,20 +181,24 @@ function run_user_shell {
     local is_dkms=$(echo $JOB_ENABLE_DKMS | tr '[:upper:]' '[:lower:]')
     echo "is_dkms=$is_dkms"
     if [ "$is_dkms" = "true" ]; then
-        if mount -t sysfs /sysfs /mnt/image/image-root/sys; then
-            echo "Mounted /sys"
+        if [[ -n "${REMOTE_BUILD_NODE}" ]]; then
+            echo " dkms mounts not set in sshd pod for remote jobs"
         else
-            echo "Failed to mount /sys"
-        fi
-        if mount -t proc /proc /mnt/image/image-root/proc; then
-            echo "Mounted /proc"
-        else
-            echo "Failed to mount /proc"
-        fi
-        if mount -t devtmpfs /devtmpfs /mnt/image/image-root/dev; then
-            echo "Mounted /dev"
-        else
-            echo "Failed to mount /dev"
+            if mount -t sysfs /sysfs /mnt/image/image-root/sys; then
+                echo "Mounted /sys"
+            else
+                echo "Failed to mount /sys"
+            fi
+            if mount -t proc /proc /mnt/image/image-root/proc; then
+                echo "Mounted /proc"
+            else
+                echo "Failed to mount /proc"
+            fi
+            if mount -t devtmpfs /devtmpfs /mnt/image/image-root/dev; then
+                echo "Mounted /dev"
+            else
+                echo "Failed to mount /dev"
+            fi
         fi
     else
         echo "DKMS not enabled"
@@ -277,9 +281,11 @@ function fetch_remote_artifacts {
         clean_remote_node
 
         # signal we are done
-        touch $PARAMETER_FILE_BUILD_FAILED
+        echo "Touching failed flag: $SIGNAL_FILE_FAILED"
+        touch $SIGNAL_FILE_FAILED
     else
         # copy image files from pod to remote machine
+        echo "Remote job succeeded"
 
         ## TODO - is there a way to copy from the container directly to the pod without the intermediate
         ##  stop in /tmp on the remote build node??? Would save space but I don't know how...

--- a/force_cmd.sh
+++ b/force_cmd.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# See if this removed the double echo...
+set -x
+
+# This script is used by the ssh_config when forwarding ssh calls to a remote
+# build node.
+if [[ -z "$SSH_ORIGINAL_COMMAND" ]]; then
+    ssh root@${REMOTE_BUILD_NODE} "podman exec -it ims-${IMS_JOB_ID} /bin/sh"
+else
+    ssh root@${REMOTE_BUILD_NODE} "podman exec ims-${IMS_JOB_ID} /bin/sh -c '$SSH_ORIGINAL_COMMAND'"

--- a/force_cmd.sh
+++ b/force_cmd.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,13 +22,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
-# See if this removed the double echo...
-set -x
-
-# This script is used by the ssh_config when forwarding ssh calls to a remote
-# build node.
 if [[ -z "$SSH_ORIGINAL_COMMAND" ]]; then
-    ssh root@${REMOTE_BUILD_NODE} "podman exec -it ims-${IMS_JOB_ID} /bin/sh"
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE}
+# NOTE: this does not currently work for sftp - try somthing like below to make it work?
+#elif [[ "$SSH_ORIGINAL_COMMAND" == "internal-sftp" ]]; then
+#    sftp -P 2022 root@${REMOTE_BUILD_NODE}
 else
-    ssh root@${REMOTE_BUILD_NODE} "podman exec ims-${IMS_JOB_ID} /bin/sh -c '$SSH_ORIGINAL_COMMAND'"
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE} $SSH_ORIGINAL_COMMAND
+fi

--- a/force_cmd.sh
+++ b/force_cmd.sh
@@ -22,11 +22,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# Set up the remote port varible
+IMAGE_ROOT_PARENT=${1:-/mnt/image}
+REMOTE_PORT_FILE=$IMAGE_ROOT_PARENT/remote_port
+REMOTE_PORT=$(cat ${REMOTE_PORT_FILE})
+
 if [[ -z "$SSH_ORIGINAL_COMMAND" ]]; then
-    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE}
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${REMOTE_PORT} root@${REMOTE_BUILD_NODE}
 # NOTE: this does not currently work for sftp - try somthing like below to make it work?
 #elif [[ "$SSH_ORIGINAL_COMMAND" == "internal-sftp" ]]; then
 #    sftp -P 2022 root@${REMOTE_BUILD_NODE}
 else
-    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@${REMOTE_BUILD_NODE} $SSH_ORIGINAL_COMMAND
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p ${REMOTE_PORT} root@${REMOTE_BUILD_NODE} $SSH_ORIGINAL_COMMAND
 fi


### PR DESCRIPTION
## Summary and Scope

This adds the ability to define a remote build node where the IMS job is run - potentially on hardware of a different architecture than the k8s worker nodes the IMS jobs is running on.

## Issues and Related PRs
* Resolves [CASM-4349](https://jira-pro.it.hpe.com:8443/browse/CASM-4349)

## Testing
### Tested on:
  * `Mug`, `Baldar`, `Tyr`

### Test description:

The new system was installed via loftsman and remote jobs were run in all configurations and combinations possible.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a moderate risk just with the amount of new code, but for the most part the existing workflows are not impacted.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
