### PR TITLE
Casmcms 8923

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-8818 - add support for ssh key injection.
 - CASMCMS-8897 - changes for aarch64 remote build.
 - CASMCMS-8895 - allow multiple concurrent remote customize jobs.
+- CASMCMS-8923 - better cleanup on unexpected exit.
 
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit


### PR DESCRIPTION
## Summary and Scope

This fixes a problem with the wrong ims python helper version and adds a trap to the remote entrypoint script to help cleanup on abnormal exit.

## Issues and Related PRs
* Resolves [CASMCMS-8923](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8923)

## Testing
### Tested on:
  * `Baldar`

### Test description:

Installed on machine and tested abnormal shutdowns to insure remote resources got cleaned up correctly.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
