### PR TITLE
CASMCMS-9226 - fix mis-spelling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- CASMCMS-9226 - fix mis-spelling.
 
 ## [1.11.0] - 2024-09-13
 ### Dependencies

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -194,7 +194,7 @@ function run_user_shell {
     fi
 
     # If setting up for dkms permissions, do that now
-    echo "JOB_ENABLE_DMKS: $JOB_ENABLE_DKMS"
+    echo "JOB_ENABLE_DKMS: $JOB_ENABLE_DKMS"
     local is_dkms=$(echo $JOB_ENABLE_DKMS | tr '[:upper:]' '[:lower:]')
     echo "is_dkms=$is_dkms"
     if [ "$is_dkms" = "true" ]; then


### PR DESCRIPTION
## Summary and Scope

This just fixes a mis-spelling in the log output.

## Issues and Related PRs

* Resolves [CASMCMS-9226](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9226)
* Resolves [CAST-37353](https://jira-pro.it.hpe.com:8443/browse/CAST-37353)

## Testing

None - this is a spelling fix in log output.

## Risks and Mitigations

None.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

