### PR TITLE
CASMCMS-8904 - Remote build changes for efficiency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- CASMCMS-8904 - optimize remote node builds.
 
 ## [1.13.0] - 2025-06-10
 ## Changed


### PR DESCRIPTION
## Summary and Scope

Make changes to the remote build process to minimize extra work copying and squashing/unsquashing the image. This pushes more work to happen on the remote node so that once the image file is transferred back to the job pod it no longer needs further modification.

This requires changes in:
ims
ims-utils
ims-sshd
ims-kiwi-ng-opensuse-x86_64-builder

## Issues and Related PRs
* Resolves [CASMCMS-8904](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8904)

## Testing
### Tested on:
  * `Mug`, and `Odin`

### Test description:

Installed the changes on the system and built complete images (from uss recipe, including shs, cos, gpu, sma, etc products) both remotely and locally and verified they booted and configured correctly. This was done with both x86 and aarch64 images. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change, but has been pretty thoroughly tested.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
